### PR TITLE
Tweaks for integration with Hatchling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ext/Hatch-Validator"]
-	path = ext/Hatch-Validator
-	url = https://github.com/CrackingShells/Hatch-Validator.git

--- a/hatch/environment_manager.py
+++ b/hatch/environment_manager.py
@@ -679,6 +679,6 @@ class HatchEnvironmentManager:
                 hatch_metadata = json.load(f)
 
             # retrieve entry points
-            ep += [hatch_metadata.get("entry_point", [])]
+            ep += [(self.environments_dir / env_name / pkg["name"] / hatch_metadata.get("entry_point")).resolve()]
 
         return ep

--- a/hatch/environment_manager.py
+++ b/hatch/environment_manager.py
@@ -657,3 +657,28 @@ class HatchEnvironmentManager:
         
         self.logger.info(f"Removed package {package_name} from environment {env_name}")
         return True
+
+    def get_servers_entry_points(self, env_name: Optional[str] = None) -> List[str]:
+        """
+        Get the list of entry points for the MCP servers of each package in an environment.
+        
+        Args:
+            env_name: Environment to get servers from (uses current if None)
+            
+        Returns:
+            List[str]: List of server entry points
+        """
+        env_name = env_name or self._current_env_name
+        if not self.environment_exists(env_name):
+            raise HatchEnvironmentError(f"Environment {env_name} does not exist")
+        
+        ep = []
+        for pkg in self._environments[env_name].get("packages", []):
+            # Open the package's metadata file
+            with open(self.environments_dir / env_name / pkg["name"] / "hatch_metadata.json", 'r') as f:
+                hatch_metadata = json.load(f)
+
+            # retrieve entry points
+            ep += [hatch_metadata.get("entry_point", [])]
+
+        return ep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hatch"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   { name = "Hatch Team" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "jsonschema>=4.0.0",
     "requests>=2.25.0",
     "packaging>=20.0",
+    "hatch_validator @ git+https://github.com/CrackingShells/Hatch-Validator.git"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-jsonschema>=4.17.3
-packaging
-./ext/Hatch-Validator


### PR DESCRIPTION
Changed the way to handle the dep to Hatch-Validator. 

### Hatch-Validator dependency:

* Removed the `Hatch-Validator` submodule from `.gitmodules` and its associated subproject commit from `ext/Hatch-Validator`. This indicates a shift away from using the submodule in favor of another integration method. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584L1-L3) [[2]](diffhunk://#diff-22b91822c2e7b21220b4a548c96b74ed036401f33fdd4f7e4cf6e2febdecb4eeL1)
* Added a dependency on `hatch_validator` via a Git URL, replacing the previous submodule approach. This streamlines dependency management by using `pyproject.toml`.

### New Method in `hatch/environment_manager.py`:

* Added the `get_servers_entry_points` method, which retrieves a list of entry points for MCP servers from package metadata in a specified environment. This method includes error handling for non-existent environments and reads metadata from `hatch_metadata.json` files.
