### PR TITLE
Fix/validator new api

### DIFF
--- a/hatch/environment_manager.py
+++ b/hatch/environment_manager.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Any, Tuple
 
 from hatch_validator.registry.registry_service import RegistryService, RegistryError
 from hatch.registry_retriever import RegistryRetriever
+from hatch_validator.package.package_service import PackageService
 from hatch.package_loader import HatchPackageLoader
 from hatch.installers.dependency_installation_orchestrator import DependencyInstallerOrchestrator
 from hatch.installers.installation_context import InstallationContext
@@ -719,8 +720,10 @@ class HatchEnvironmentManager:
             with open(self.environments_dir / env_name / pkg["name"] / "hatch_metadata.json", 'r') as f:
                 hatch_metadata = json.load(f)
 
+            package_service = PackageService(hatch_metadata)
+
             # retrieve entry points
-            ep += [(self.environments_dir / env_name / pkg["name"] / hatch_metadata.get("entry_point")).resolve()]
+            ep += [(self.environments_dir / env_name / pkg["name"] / package_service.get_hatch_mcp_entry_point()).resolve()]
 
         return ep
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "packaging>=20.0",
     "docker>=7.1.0",
     
-    "hatch_validator @ git+https://github.com/CrackingShells/Hatch-Validator.git@v0.7.1-dev.1"
+    "hatch_validator @ git+https://github.com/CrackingShells/Hatch-Validator.git@v0.7.1"
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "packaging>=20.0",
     "docker>=7.1.0",
     
-    "hatch_validator @ git+https://github.com/CrackingShells/Hatch-Validator.git@v0.7.0"
+    "hatch_validator @ git+https://github.com/CrackingShells/Hatch-Validator.git@v0.7.1-dev.1"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Using version `v0.7.1` of `hatch_validator` to improve how entry points are retrieved by using the new `PackageService` from the `hatch_validator`.

**Dependency update:**

* Updated the `hatch_validator` dependency in `pyproject.toml` from version `v0.7.0` to `v0.7.1`, ensuring the project uses the latest fixes from the package https://github.com/CrackingShells/Hatch-Validator/pull/15

**Entry point resolution improvements:**

* In the `get_servers_entry_points` method, replaced direct access to the entry point in `hatch_metadata` with a call to `PackageService.get_hatch_mcp_entry_point()`, making entry point retrieval more robust and maintainable.